### PR TITLE
If _MAX_INT_DIG is not otherwise defined, define it directly in Watch…

### DIFF
--- a/WatchySim/Watchy.cpp
+++ b/WatchySim/Watchy.cpp
@@ -1,6 +1,10 @@
 #include <ctime>
 #include "Watchy.h"
 
+#ifndef _MAX_INT_DIG
+#define _MAX_INT_DIG    32
+#endif
+
 Watchy::Watchy() {
     resetTime();
 }


### PR DESCRIPTION
…y.cpp. This gets around a missing definition in the 2022 MSVC version of yvals.h.